### PR TITLE
Fix isearch session state init when flash-isearch-enabled is nil

### DIFF
--- a/flash-isearch.el
+++ b/flash-isearch.el
@@ -86,18 +86,19 @@ When set (e.g. \";\"), you must type trigger + label to jump."
 
 (defun flash-isearch--start ()
   "Start flash search mode."
+  (setq flash-isearch--active nil)
+  (setq flash-isearch--in-session t)
+  (setq flash-isearch--original-buffer (current-buffer))
+  (let ((state (flash-state-create
+                (if (bound-and-true-p flash-multi-window)
+                    (window-list nil 'no-minibuf)
+                  (list (selected-window))))))
+    ;; Search integration: check label conflicts in whole buffer
+    ;; because search can jump to matches anywhere, not just visible area
+    (setf (flash-state-whole-buffer state) t)
+    (setq flash-isearch--state state))
   (when flash-isearch-enabled
-    (setq flash-isearch--active t)
-    (setq flash-isearch--in-session t)
-    (setq flash-isearch--original-buffer (current-buffer))
-    (let ((state (flash-state-create
-                  (if (bound-and-true-p flash-multi-window)
-                      (window-list nil 'no-minibuf)
-                    (list (selected-window))))))
-      ;; Search integration: check label conflicts in whole buffer
-      ;; because search can jump to matches anywhere, not just visible area
-      (setf (flash-state-whole-buffer state) t)
-      (setq flash-isearch--state state))))
+    (flash-isearch--toggle)))
 
 (defun flash-isearch--stop ()
   "Stop flash search mode and clean up."


### PR DESCRIPTION
## Summary

Two bugs in `flash--loop` input handling:

1. `char-to-string` called unconditionally on `read-char` result — modified keys (e.g. `M-m` = 134217837) cause
   `(wrong-type-argument characterp)` because `char-to-string` only accepts 0-255
2. The "add to pattern" branch `((not prefix) ...)` only checked for an active label prefix, not whether the key was
   printable. When `char-str` was nil (non-printable key), `(concat pattern nil)` left the pattern unchanged and the
   loop continued — silently swallowing control keys like `C-s`

Fix: restrict `char-str` to printable ASCII (32-126), guard the pattern-extension branch with `char-str`, and add a
catch-all that pushes unhandled keys back via `unread-command-events` so they are processed by the normal command loop.

## Test plan

- `M-x flash-jump`, type a few chars, then press `M-m` — should exit flash and run `M-m`'s global binding
- `M-x flash-jump`, press `C-s` — should exit flash and start isearch
- `M-x flash-jump`, type pattern, press label key — label jump still works
- `M-x flash-jump`, press ESC / RET / backspace — still handled as before