### PR TITLE
Fix flash-jump overwriting mark when region is active

### DIFF
--- a/flash-jump.el
+++ b/flash-jump.el
@@ -19,7 +19,6 @@
 (defvar flash-nohlsearch)
 
 ;;; Forward declarations for evil
-(defvar evil-state)
 (defvar evil-ex-search-highlight-all)
 (declare-function evil-ex-nohighlight "evil-ex")
 
@@ -37,12 +36,10 @@ Clears highlighting if `flash-nohlsearch' is non-nil."
           (end-pos (flash-match-end-pos match))
           (fold (flash-match-fold match))
           (jump-pos flash-jump-position))
-      ;; Save to jumplist before jumping.
-      ;; Skip in evil visual state: push-mark overwrites the selection
-      ;; anchor (mark), and the evil motion's :jump t handles jumplist.
+      ;; Save to jumplist before jumping (same idiom as isearch-done).
+      ;; Skip when mark is active to preserve region/selection anchor.
       (when (and flash-jumplist
-                 (not (and (bound-and-true-p evil-local-mode)
-                           (eq evil-state 'visual))))
+                 (not (and transient-mark-mode mark-active)))
         (push-mark nil t))
       ;; Switch window if needed
       (unless (eq win (selected-window))

--- a/flash.el
+++ b/flash.el
@@ -148,7 +148,9 @@ When nil, only labels are shown, keeping original syntax highlighting."
 (defcustom flash-jumplist t
   "When non-nil, save position to mark ring before jumping.
 This allows returning to the previous position with `C-u C-SPC'
-or `C-x C-SPC' (global mark), or with evil's `C-o'."
+or `C-x C-SPC' (global mark), or with evil's `C-o'.
+When the mark is active (region or evil visual state), the mark
+is not pushed, preserving the existing selection anchor."
   :type 'boolean
   :group 'flash)
 


### PR DESCRIPTION
## Summary
- Skip `push-mark` when `transient-mark-mode` and `mark-active` are both true, using the same idiom as `isearch-done`
- Replaces the evil-specific guard with a general check that covers both vanilla Emacs regions and evil visual state
- Adds tests for mark preservation with active region and mark pushing without region

Fixes #1