### PR TITLE
Fix void flash-case-fold when flash-isearch loads before flash

### DIFF
--- a/flash-isearch.el
+++ b/flash-isearch.el
@@ -20,11 +20,7 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'flash-state)
-(require 'flash-search)
-(require 'flash-label)
-(require 'flash-highlight)
-(require 'flash-jump)
+(require 'flash)
 
 ;;; Customization
 
@@ -78,7 +74,6 @@ When set (e.g. \";\"), you must type trigger + label to jump."
 (defvar isearch-string)
 (defvar isearch-forward)
 (defvar isearch-mode-map)
-(defvar flash-multi-window)
 
 (declare-function isearch-exit "isearch")
 


### PR DESCRIPTION
## Summary
- `flash-isearch.el` required sub-modules directly, bypassing `flash.el` where all defcustoms are defined
- Sub-modules only have bare `defvar` forward declarations (no default value), so any variable defined in `flash.el` (`flash-case-fold`, `flash-labels`, `flash-backdrop`, `flash-jumplist`, etc.) would be void when isearch ran before `flash-jump`
- Replace individual sub-module requires with `(require 'flash)` and remove the now-redundant `flash-multi-window` forward declaration
- No circular dependency: `flash.el` does not require `flash-isearch`

Fixes #2