### PR TITLE
Add flash-mode-map to allow custom key bindings

### DIFF
--- a/flash.el
+++ b/flash.el
@@ -180,6 +180,9 @@ Flash-isearch always searches folds regardless of this setting."
   :type 'boolean
   :group 'flash)
 
+(defcustom flash-keymap nil
+  "Keymap for unhandled keys.")
+
 ;;; State for continue functionality
 
 (defvar flash--last-pattern nil
@@ -299,6 +302,12 @@ Returns t if jump was made, nil if cancelled."
          ((and char-str (not prefix))
           (setf (flash-state-pattern state)
                 (concat pattern char-str)))
+
+         ;; key bound in flash-keymap
+         ((and (keymapp flash-keymap)
+               (lookup-key flash-keymap (char-to-string char)))
+          (call-interactively (lookup-key flash-keymap (char-to-string char)))
+          (throw 'flash-done nil))
 
          ;; Unhandled key - exit and push back for normal command loop
          ((not char-str)

--- a/flash.el
+++ b/flash.el
@@ -180,7 +180,7 @@ Flash-isearch always searches folds regardless of this setting."
   :type 'boolean
   :group 'flash)
 
-(defcustom flash-keymap nil
+(defcustom flash-mode-map nil
   "Keymap for unhandled keys.")
 
 ;;; State for continue functionality
@@ -303,10 +303,10 @@ Returns t if jump was made, nil if cancelled."
           (setf (flash-state-pattern state)
                 (concat pattern char-str)))
 
-         ;; key bound in flash-keymap
-         ((and (keymapp flash-keymap)
-               (lookup-key flash-keymap (char-to-string char)))
-          (call-interactively (lookup-key flash-keymap (char-to-string char)))
+         ;; key bound in flash-mode-map
+         ((and (keymapp flash-mode-map)
+               (lookup-key flash-mode-map (char-to-string char)))
+          (call-interactively (lookup-key flash-mode-map (char-to-string char)))
           (throw 'flash-done nil))
 
          ;; Unhandled key - exit and push back for normal command loop


### PR DESCRIPTION
Add flash-mode-map to allow custom key bindings. 

It's probably a good idea to use this map for the default ESC, RET and backspace key handling too, but that requires a bit of rewrite to make the state a global variable.