### PR TITLE
Add flash-after-jump-hook run after a successful jump

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,6 +138,7 @@ This is useful for quickly selecting or operating on a surrounding code structur
 | ~flash-search-history~     | ~nil~                          | Add search pattern to isearch history              |
 | ~flash-min-pattern-length~ | ~0~                            | Minimum pattern length before labels appear        |
 | ~flash-search-folds~       | ~nil~                          | Search inside folded (invisible) regions           |
+| ~flash-after-jump-hook~    | ~nil~                          | Hook run in the target buffer after a successful jump |
 
 **** Label Positions
 

--- a/flash-jump.el
+++ b/flash-jump.el
@@ -21,6 +21,7 @@
 (defvar flash-jump-position)
 (defvar flash-jumplist)
 (defvar flash-nohlsearch)
+(defvar flash-after-jump-hook)
 
 ;;; Forward declarations for evil
 (defvar evil-state)
@@ -76,6 +77,8 @@ Clears highlighting if `flash-nohlsearch' is non-nil."
       ;; Clear search highlighting if requested
       (when flash-nohlsearch
         (flash--clear-search-highlight))
+      ;; Notify observers now that point has landed in the target buffer.
+      (run-hooks 'flash-after-jump-hook)
       t)))
 
 (defun flash--clear-search-highlight ()

--- a/flash.el
+++ b/flash.el
@@ -154,6 +154,14 @@ or `C-x C-SPC' (global mark), or with evil's `C-o'."
   :type 'boolean
   :group 'flash)
 
+(defcustom flash-after-jump-hook nil
+  "Hook run after a successful jump.
+Functions are called with no arguments in the target buffer, after point
+has moved to the match (and any window/buffer switch and unfold).
+Not run when a session is cancelled or returns to the start position."
+  :type 'hook
+  :group 'flash)
+
 (defcustom flash-search-history nil
   "When non-nil, add search pattern to Emacs search history.
 The pattern will appear in `isearch' history."


### PR DESCRIPTION
Run a new hook at the end of flash-jump-to-match, the single function
every jump path funnels through (label jumps, first-match, isearch
integration), in the target buffer with point on the match.
Lets observers react to a completed jump; not run when a session is
cancelled or returns to the start position.

---

Actual use-case for me is that I use it with my terminal emulator ghostel,
and by default it's in "semi-char mode" which forwards all keys to the terminal,
but after a flash-jump I would like to automatically switch to copy-mode
so I can navigate, select and copy freely.